### PR TITLE
docs: fix trailing whitespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,4 @@ cd packages/typescript && pnpm test
 ## License
 
 [MIT](./LICENSE) — BankOfAI
+


### PR DESCRIPTION
Minor cleanup - removes trailing whitespace for consistency.